### PR TITLE
Use USWDS CSS and JS by default

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,1 @@
 title: This is the site title
-
-styles:
-  - /assets/uswds/css/uswds.min.css
-
-scripts:
-  - src: /assets/uswds/js/uswds.min.js
-    async: true

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,17 @@
-{% assign _scripts = '' | split: '' | push: site.scripts | push: layout.scripts | push: page.scripts | uniq %}
+{% assign _scripts = '' | split: '' %}
+{% assign _async_marker = 'uswds_async=true' %}
+{% assign _site_scripts = site.scripts %}
+{% unless _site_scripts -%}
+  {% assign _uswds_js = '/assets/uswds/js/uswds.min.js' | append: '?' | append: _async_marker %}
+  {% assign _site_scripts = '' | split: ''
+    | push: _uswds_js %}
+{% endunless %}
+{% assign _scripts = _scripts
+  | push: _site_scripts
+  | push: layout.scripts
+  | push: page.scripts
+  | uniq %}
 {% for _list in _scripts %}{% for _script in _list %}
-<script src="{{ _script.src | default: _script | relative_url }}" {% if _script.async %}async{% endif %}></script>
+  {% assign _src = _script.src | default: _script %}
+<script src="{{ _src | replace: _async_marker, '' | relative_url }}"{% if _script.async or _src contains _async_marker %} async{% endif %}></script>
 {% endfor %}{% endfor %}

--- a/_includes/styles.html
+++ b/_includes/styles.html
@@ -1,4 +1,15 @@
-{% assign _styles = '' | split: '' | push: site.styles | push: layout.styles | push: page.styles | uniq %}
+{% assign _styles = '' | split: '' %}
+{% assign _site_styles = site.styles %}
+{% unless _site.styles -%}
+  {% assign _uswds_css = '/assets/uswds/css/uswds.min.css' %}
+  {% assign _site_styles = '' | split: ''
+    | push: _uswds_css %}
+{% endunless %}
+{% assign _styles = _styles
+  | push: _site_styles
+  | push: layout.styles
+  | push: page.styles
+  | uniq %}
 {% for _list in _styles %}{% for _style in _list %}
 <link rel="stylesheet"
   href="{{ _style.href | default: _style | relative_url }}"

--- a/jekyll-uswds.gemspec
+++ b/jekyll-uswds.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-uswds"
-  spec.version       = "0.2.1"
+  spec.version       = "0.2.0"
   spec.authors       = ["Shawn Allen"]
   spec.email         = ["shawn.allen@gsa.gov"]
 

--- a/jekyll-uswds.gemspec
+++ b/jekyll-uswds.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-uswds"
-  spec.version       = "0.1.1"
+  spec.version       = "0.2.1"
   spec.authors       = ["Shawn Allen"]
   spec.email         = ["shawn.allen@gsa.gov"]
 


### PR DESCRIPTION
My colleagues @gemfarmer and @line47 ran into an issue using the theme today in which the CSS and JS weren't loading, and after a bit of digging I realized that I hadn't documented the need to manually copy the `styles` and `scripts` config entries from [this repo's `_config.yml`](https://github.com/18F/jekyll-uswds/blob/6caf418158a1311d94fcbb5d75d653ede6968a74/_config.yml#L3-L8). Whoops!

My solution for this issue is eliminate the requirement for those config keys and have both the [styles](https://github.com/18F/jekyll-uswds/blob/master/_includes/styles.html) and [scripts](https://github.com/18F/jekyll-uswds/blob/master/_includes/scripts.html) includes use USWDS assets by default if they aren't provided.

Because we want the JS to be async and there's no easy way create objects in Liquid templates, I added support for a special `?uswds_asyc=true` query string parameter on script URL strings that triggers addition of the `async` attribute and is stripped from the `src` attribute, which yields:

```html
<script src="/assets/uswds/js/uswds.min.js" async></script>
```

Très magnifique! 😗 

This is a minor version bump to v0.2.0.