### PR TITLE
Fix default styles typo; add asset defaults docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This is a [Jekyll theme](https://jekyllrb.com/docs/themes/) for the
   1. [Site title](#site-title)
   1. [Navigation](#navigation)
     1. [Page subnavigation](#page-subnavigation)
+1. [Assets](#assets)
   1. [Stylesheets](#stylesheets)
   1. [Scripts](#scripts)
   1. [Asset load order](#asset-load-order)
@@ -185,6 +186,24 @@ redcarpet:
   extensions:
     - with_toc_data
 ```
+
+## Assets
+
+The [stylesheet](_includes/styles.html) and [script](_includes/scripts.html)
+includes each incorporate the Standards CSS and JS files if the corresponding
+`styles` and `scripts` lists aren't defined in your `_config.yml`. So unless
+you add one or both of those manually, your HTML will include the following:
+
+```html
+<!-- in the <head> -->
+<link rel="stylesheet" href="/assets/uswds/css/uswds.min.css" media="screen">
+<!-- before </body> -->
+<script src="/assets/uswds/js/uswds.min.js" async>
+```
+
+Read more about customizing [stylesheets](#stylesheets) and [scripts](#scripts)
+below.
+
 
 ### Stylesheets
 

--- a/_includes/styles.html
+++ b/_includes/styles.html
@@ -1,6 +1,6 @@
 {% assign _styles = '' | split: '' %}
 {% assign _site_styles = site.styles %}
-{% unless _site.styles -%}
+{% unless _site_styles -%}
   {% assign _uswds_css = '/assets/uswds/css/uswds.min.css' %}
   {% assign _site_styles = '' | split: ''
     | push: _uswds_css %}

--- a/jekyll-uswds.gemspec
+++ b/jekyll-uswds.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-uswds"
-  spec.version       = "0.2.0"
+  spec.version       = "0.2.1"
   spec.authors       = ["Shawn Allen"]
   spec.email         = ["shawn.allen@gsa.gov"]
 


### PR DESCRIPTION
Thanks to @hursey013 for pointing out a typo in the stylesheets include that was preventing custom styles in `_config.yml` from being used. That's fixed, and I've added a new "Assets" heading to the docs that includes some notes about the default CSS and JS, then leads into how to override them.

Brian, would you mind testing this? You should be able to reference this branch in your `Gemfile` like so:

```ruby
gem 'jekyll-uswds', :git => 'https://github.com/18F/jekyll-uswds.git', \
  :branch => 'fix-default-styles'
```

Thank you!