### PR TITLE
Fix footer logo image URLs; add link support

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -33,10 +33,12 @@
   <div class="usa-footer-secondary_section">
     <div class="usa-grid">
       <div class="usa-footer-logo usa-width-one-half">
-        {% for logo in footer.logos %}
-        <img class="usa-footer-logo-img" src="{{ logo.src }}" alt="{{ logo.alt }}"
+        {% for logo in footer.logos -%}
+          {% if logo.url %}<a href="{{ logo.href | relative_url }}">{% endif %}
+        <img class="usa-footer-logo-img" src="{{ logo.src | relative_url }}" alt="{{ logo.alt }}"
           {% if logo.width %}width="{{ logo.width }}"{% endif %}
           {% if logo.height %}height="{{ logo.height }}"{% endif %}>
+          {% if logo.url %}</a>{% endif %}
         {% endfor %}
         {% if footer.heading %}
         <h3 class="usa-footer-logo-heading">{{ footer.heading }}</h3>

--- a/jekyll-uswds.gemspec
+++ b/jekyll-uswds.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-uswds"
-  spec.version       = "0.2.2"
+  spec.version       = "0.3.0"
   spec.authors       = ["Shawn Allen"]
   spec.email         = ["shawn.allen@gsa.gov"]
 


### PR DESCRIPTION
This PR ensures that footer logo URLs are prefixed with `site.baseurl`, and adds support for a `url` property in `site.data.footer.logos[*]`, which wraps the image in a link.

Bumps to version 0.3.0.