### PR TITLE
Update logo to link to home page

### DIFF
--- a/_includes/components/header.html
+++ b/_includes/components/header.html
@@ -7,7 +7,7 @@
     <button class="usa-menu-btn">Menu</button>
     <div class="usa-logo" id="logo">
       <em class="usa-logo-text">
-        <a href="#" accesskey="1" title="Home" aria-label="Home">{{ header.title | default: site.title }}</a>
+        <a href="{{ site.baseurl }}" accesskey="1" title="Home" aria-label="Home">{{ header.title | default: site.title }}</a>
       </em>
     </div>
   </div>


### PR DESCRIPTION
It's currently linked to `#` and this makes it link to the home page.