### PR TITLE
Fix missing anchor config script include

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -10,7 +10,7 @@
     {% assign _anchor_conf_js = '/assets/js/anchor.js' %}
     {% assign _site_scripts = _site_scripts
       | push: _anchor_js
-      | push: _main_js %}
+      | push: _anchor_conf_js %}
   {% endif %}
 {% endunless %}
 {% if site.private_eye %}


### PR DESCRIPTION
Fixes #188.

In _includes/scripts.html, the anchor config path was assigned but the script array pushed the wrong variable. So the page loaded anchor.min.js, but never loaded assets/js/anchor.js. Without that file, anchors.add(...) never ran when anchor_js_targets was set.

This switches the pushed variable to _anchor_conf_js, so both scripts are rendered.

I verified this by rendering _includes/scripts.html with anchor_js_targets enabled and confirming the output includes /assets/js/vendor/anchor.min.js and /assets/js/anchor.js.