### PR TITLE
Fix Private Eye lock icon underline

### DIFF
--- a/assets/js/vendor/private_eye.js
+++ b/assets/js/vendor/private_eye.js
@@ -3,7 +3,7 @@
     'use strict';
   
     // The line below differs from private eye v2.0. We need to update the source file.
-    var STYLES = 'a.private-link::after { content: "\\1F512"; font-size: 0.75em; text-decoration: none }';
+    var STYLES = 'a.private-link::after { content: "\\1F512"; font-size: 0.75em; display: inline-block; vertical-align: top; text-decoration: none; }';
     var STYLES_ID = '_privateEye-styles';
   
     var DEFAULT_OPTIONS = {


### PR DESCRIPTION
Fixes #223.

The lock icon from Private Eye is added with a pseudo-element on the anchor. Even with text-decoration set to none, the icon can still pick up underline styling because it stays in the same inline text flow.

This updates the injected style so the icon renders as an inline-block and stays top-aligned. That keeps the same lock glyph and size while preventing the icon underline.

I verified the script still parses and runs by executing assets/js/vendor/private_eye.js in a Node test harness, checking that links are tagged as private-link and the injected style includes display: inline-block plus vertical-align: top.